### PR TITLE
Set regulators for Sony Yuga to downstream values

### DIFF
--- a/arch/arm/boot/dts/qcom-apq8064-sony-xperia-yuga.dts
+++ b/arch/arm/boot/dts/qcom-apq8064-sony-xperia-yuga.dts
@@ -202,8 +202,8 @@
 				};
 
 				l11 {
-					regulator-min-microvolt = <3000000>;
-					regulator-max-microvolt = <3000000>;
+					regulator-min-microvolt = <2850000>;
+					regulator-max-microvolt = <2850000>;
 					bias-pull-down;
 				};
 
@@ -286,8 +286,8 @@
 				};
 
 				l29 {
-					regulator-min-microvolt = <2000000>;
-					regulator-max-microvolt = <2000000>;
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
 					bias-pull-down;
 				};
 


### PR DESCRIPTION
Set regulator l11 to 2850000 and l29 to 1800000, same values as
downstream kernel.